### PR TITLE
Fix: resolved #31 - Recommender fails with 'too many boolean clauses' error

### DIFF
--- a/lib/ncbo_ontology_recommender/evaluators/detail_evaluator.rb
+++ b/lib/ncbo_ontology_recommender/evaluators/detail_evaluator.rb
@@ -36,7 +36,7 @@ module OntologyRecommender
         detail_score_syns = sum_syns.to_f / best_annotations_ont.size.to_f
         detail_score_props = sum_props.to_f / best_annotations_ont.size.to_f
         detail_score = (detail_score_defs + detail_score_syns + detail_score_props).to_f / 3.to_f
-        return OntologyRecommender::Evaluators::DetailResult.new(detail_score.round(3), detail_score_defs.round(3),
+        OntologyRecommender::Evaluators::DetailResult.new(detail_score.round(3), detail_score_defs.round(3),
                                                                  detail_score_syns.round(3), detail_score_props.round(3))
       end
 
@@ -65,7 +65,7 @@ module OntologyRecommender
             [(defined? cls.definition) != nil ? cls.definition.size : 0,
              (defined? cls.synonym) != nil ? cls.synonym.size : 0,
              (defined? cls.property) != nil ? cls.property.size : 0] }
-        return hash
+        hash
       end
 
       # Computes the detail score for a specific feature (e.f. definitions, synonyms, properties) (range [0,1])
@@ -89,7 +89,7 @@ module OntologyRecommender
         get_edismax_query("avoid_search_mangling", params)
         params.delete("ontology_acronyms")
         params["qf"] = "resource_id"
-        params["fq"] << " AND #{get_quoted_field_query_param(class_ids, "OR", "resource_id")}"
+        params["fq"] << " AND #{get_terms_field_query_param(class_ids, "resource_id")}"
         params["rows"] = 99999
         # Replace fake query with wildcard
         resp = LinkedData::Models::Class.search("*:*", params)
@@ -107,28 +107,21 @@ module OntologyRecommender
           doc[:properties] = MultiJson.load(doc.delete(:propertyRaw))
           populated_classes << LinkedData::Models::Class.read_only(doc)
         end
-        return populated_classes
+        populated_classes
       end
 
       private
-      def get_quoted_field_query_param(words, clause, fieldName="")
-        query = fieldName.empty? ? "" : "#{fieldName}:"
-        if (words.length > 1)
-          query << "("
+
+      def get_terms_field_query_param(values, field_name)
+        return "" if values.nil? || values.empty?
+
+        escaped_values = values.map do |value|
+          value.to_s.gsub('\\', '\\\\\\').gsub(',', '\\,').gsub('"', '\\"')
         end
-        query << "\"#{words[0]}\""
-        if (words.length > 1)
-          words[1..-1].each do |word|
-            query << " #{clause} \"#{word}\""
-          end
-        end
-        if (words.length > 1)
-          query << ")"
-        end
-        return query
+
+        "_query_:\"{!terms f=#{field_name}}#{escaped_values.join(',')}\""
       end
 
-      private
       def get_edismax_query(text, params={})
         params["defType"] = "edismax"
         params["stopwords"] = "true"
@@ -141,10 +134,10 @@ module OntologyRecommender
         end
         params["qf"] = "resource_id^100"
         acronyms = params["ontology_acronyms"] || restricted_ontologies_to_acronyms(params)
-        filter_query = get_quoted_field_query_param(acronyms, "OR", "submissionAcronym")
+        filter_query = get_terms_field_query_param(acronyms, "submissionAcronym")
         params["fq"] = filter_query
         params["q"] = query
-        return query
+        query
       end
 
       # see https://github.com/rsolr/rsolr/issues/101

--- a/test/evaluators/test_detail_evaluator.rb
+++ b/test/evaluators/test_detail_evaluator.rb
@@ -27,7 +27,6 @@ class TestSpecializationEvaluator < TestCase
     result1 = @@detail_evaluator.evaluate(annotations_all_hash, annotations_all_hash['MCCLTEST-0'])
     result2 = @@detail_evaluator.evaluate(annotations_all_hash, annotations_all_hash['ONTOMATEST-0'])
     result3 = @@detail_evaluator.evaluate(annotations_all_hash, annotations_all_hash['BROTEST-0'])
-    binding.pry
     assert(result1.propertiesScore > 0 && result2.propertiesScore > 0 && result3.propertiesScore > 0)
     assert_equal(0, result1.definitionsScore)
     assert_equal(0, result2.definitionsScore)

--- a/test/evaluators/test_detail_evaluator.rb
+++ b/test/evaluators/test_detail_evaluator.rb
@@ -14,6 +14,16 @@ class TestSpecializationEvaluator < TestCase
   def self.after_suite
   end
 
+  def test_terms_filter_does_not_emit_boolean_clauses_for_large_value_sets
+    ids = (1..1100).map { |i| "http://example.org/classes/#{i}" }
+    query = @@detail_evaluator.send(:get_terms_field_query_param, ids, "resource_id")
+
+    assert_match(/\A_query_:"\{!terms f=resource_id\}/, query)
+    assert(query.include?(ids.first))
+    assert(query.include?(ids.last))
+    refute_match(/\bOR\b/, query)
+  end
+
   def test_evaluate
     input = 'article, hormone antagonists, software, activity'
     input_type = 2

--- a/test/evaluators/test_detail_evaluator.rb
+++ b/test/evaluators/test_detail_evaluator.rb
@@ -15,8 +15,9 @@ class TestSpecializationEvaluator < TestCase
   end
 
   def test_terms_filter_does_not_emit_boolean_clauses_for_large_value_sets
+    detail_evaluator = OntologyRecommender::Evaluators::DetailEvaluator.new(1, 1, 1)
     ids = (1..1100).map { |i| "http://example.org/classes/#{i}" }
-    query = @@detail_evaluator.send(:get_terms_field_query_param, ids, "resource_id")
+    query = detail_evaluator.send(:get_terms_field_query_param, ids, "resource_id")
 
     assert_match(/\A_query_:"\{!terms f=resource_id\}/, query)
     assert(query.include?(ids.first))


### PR DESCRIPTION
## Summary

Fixes #31.

The Recommender detail evaluator was still building Solr filter queries with quoted boolean `OR` clauses for ontology acronyms and class resource IDs. With large recommendation result sets, those filters could exceed Solr's boolean clause limit and cause the BioPortal Recommender flow to fail with:

> Problem getting recommendations, please try again.

The production stack trace in #31 points to `DetailEvaluator#populate_classes`, where the generated `submissionAcronym:(... OR ...)` and `resource_id:(... OR ...)` filters could trigger Solr's `too many boolean clauses` error.

This updates the Recommender to use Solr `{!terms}` filter queries for those multi-value filters, matching the recent `ontologies_api` change from `get_quoted_field_query_param` to `get_terms_field_query_param`.

## Changes

- Replaced boolean `OR` filter construction with `get_terms_field_query_param`
- Applied terms-query filtering to:
  - `resource_id` class lookups in `populate_classes`
  - `submissionAcronym` filters in `get_edismax_query`
- Removed the old quoted boolean helper from the detail evaluator
- Added a regression test covering large value sets that would previously emit too many boolean clauses

## Verification

- Added unit coverage verifying large detail-evaluator filter value sets use Solr `{!terms}` syntax instead of boolean `OR` clauses